### PR TITLE
#34 -Remove header key parsing

### DIFF
--- a/action.go
+++ b/action.go
@@ -52,7 +52,7 @@ func (action Action) setup() (*http.Request, error) {
 	}
 	if action.Headers != nil {
 		for k, v := range action.Headers {
-			req.Header.Add(parseString(k), parseString(v))
+			req.Header.Add(k, parseString(v))
 		}
 	}
 	return req, nil


### PR DESCRIPTION
As commented in #34 the key of a header doesn't need to be parsed, so the parsing has been removed.