### PR TITLE
#46 -Add initial Collection template

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -1,0 +1,11 @@
+package tranquility
+
+//Collection provides an abstraction for a group of Requests defined by a user
+type Collection []*Request
+
+//Run perfoms the full request in the following order PreAction, Action and Test
+func (col Collection) Run() {
+	for i := range col {
+		col[i].Run()
+	}
+}


### PR DESCRIPTION
This PR adds the initial Collection template. At the moment is a very basic template but it will be extended in the future as commented in some of the issues. The following snippet of code is an example of usage of a Collection.
```
collection := tranquility.Collection{&tranquility.Request{PreAction: basicPreAction, Action: a, Test: simple200Test}, &tranquility.Request{PreAction: modifyMethod, Action: a2, Test: simple200Test}}
collection.Run()

```