### PR TITLE
#48 -Fix panic error in case parameters or headers aren't init before

### DIFF
--- a/request.go
+++ b/request.go
@@ -7,8 +7,19 @@ type Request struct {
 	Test      func(res *Response)
 }
 
+//verifyAction initializes parameters and headers if they are null to avoid errors with PreActions
+func verifyAction(req *Request) {
+	if req.Action.Parameters == nil {
+		req.Action.Parameters = map[string]string{}
+	}
+	if req.Action.Headers == nil {
+		req.Action.Headers = map[string]string{}
+	}
+}
+
 //Run perfoms the full request in the following order PreAction, Action and Test
 func (req Request) Run() {
+	verifyAction(&req)
 	if req.PreAction != nil {
 		req.PreAction(req.Action)
 	}


### PR DESCRIPTION
This PR prevents `panic: assignment to entry in nil map` from happening in case users wants to modify parameters or headers even though they aren't initialized 